### PR TITLE
[#3] redis 트랜잭션 예제 작성

### DIFF
--- a/concurrency/build.gradle.kts
+++ b/concurrency/build.gradle.kts
@@ -6,6 +6,9 @@ dependencies {
     implementation(libs.spring.boot.starter)
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.actuator)
+    testImplementation(libs.spring.boot.starter.test)
+    implementation(libs.spring.boot.starter.data.redis)
+
     implementation(libs.spring.boot.starter.redisson)
     implementation("io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-x86_64") // 인텔 맥 DNS 설정
 }

--- a/concurrency/build.gradle.kts
+++ b/concurrency/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     implementation(libs.spring.boot.starter.data.redis)
 
     implementation(libs.spring.boot.starter.redisson)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.redis)
     implementation("io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-x86_64") // 인텔 맥 DNS 설정
 }
 

--- a/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/RedisConcurrencyExpBootstrap.kt
+++ b/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/RedisConcurrencyExpBootstrap.kt
@@ -2,7 +2,9 @@ package kr.co.taek.dev.redis.example.concurrency
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.transaction.annotation.EnableTransactionManagement
 
+@EnableTransactionManagement
 @SpringBootApplication
 class RedisConcurrencyExpBootstrap
 

--- a/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/config/LettuceConfig.kt
+++ b/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/config/LettuceConfig.kt
@@ -1,0 +1,29 @@
+package kr.co.taek.dev.redis.example.concurrency.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class LettuceConfig {
+    @Bean
+    fun lettuceRedisTemplate(): RedisTemplate<String, Int> {
+        return RedisTemplate<String, Int>().apply {
+            connectionFactory = lettuceConnectionFactory()
+            keySerializer = StringRedisSerializer()
+            valueSerializer = GenericJackson2JsonRedisSerializer()
+            setEnableTransactionSupport(true)
+
+        }
+    }
+
+    @Primary
+    @Bean
+    fun lettuceConnectionFactory(): LettuceConnectionFactory {
+        return LettuceConnectionFactory("localhost", 6379)
+    }
+}

--- a/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/config/LettuceConfig.kt
+++ b/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/config/LettuceConfig.kt
@@ -18,7 +18,6 @@ class LettuceConfig {
             keySerializer = StringRedisSerializer()
             valueSerializer = GenericJackson2JsonRedisSerializer()
             setEnableTransactionSupport(true)
-
         }
     }
 

--- a/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/config/LettuceConfig.kt
+++ b/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/config/LettuceConfig.kt
@@ -3,6 +3,7 @@ package kr.co.taek.dev.redis.example.concurrency.config
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
@@ -11,7 +12,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 @Configuration
 class LettuceConfig {
     @Bean
-    fun lettuceRedisTemplate(): RedisTemplate<String, Int> {
+    fun redisTemplate(): RedisTemplate<String, Int> {
         return RedisTemplate<String, Int>().apply {
             connectionFactory = lettuceConnectionFactory()
             keySerializer = StringRedisSerializer()
@@ -21,6 +22,7 @@ class LettuceConfig {
         }
     }
 
+    @Profile("!test")
     @Primary
     @Bean
     fun lettuceConnectionFactory(): LettuceConnectionFactory {

--- a/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationService.kt
+++ b/concurrency/src/main/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationService.kt
@@ -1,0 +1,75 @@
+package kr.co.taek.dev.redis.example.concurrency.transaction
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.core.RedisOperations
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.SessionCallback
+import org.springframework.stereotype.Service
+import kotlin.math.pow
+import kotlin.random.Random
+
+private val log = KotlinLogging.logger {}
+
+@Service
+class AtomicOperationService(
+    private val redisTemplate: RedisTemplate<String, Int>,
+) {
+    fun increment(
+        key: String,
+        retryable: Boolean = false,
+        retryCnt: Int = 3,
+        backOff: Long = 1000L,
+    ) {
+        if (retryable) {
+            var retry = 0
+            while (retry < retryCnt) {
+                try {
+                    incrementWithRedisCallback(key)
+                    break
+                } catch (e: Exception) {
+                    log.error { "Error: $e" }
+                    retry++
+
+                    var backoffTime = backOff * 2.00.pow(retry.toDouble()).toLong()
+                    backoffTime += Random.nextInt(100) // 무작위성 추가, thundering herd problem (즉, 여러 클라이언트가 동시에 재시도를 하는 문제) 방지
+
+                    try {
+                        Thread.sleep(backoffTime) // 계산된 시간만큼 대기
+                    } catch (ie: InterruptedException) {
+                        log.warn { "Thread interrupted during backoff sleep" }
+                        Thread.currentThread().interrupt() // 현재 스레드의 인터럽트 상태를 설정
+                        break
+                    }
+                }
+
+            }
+        } else {
+            incrementWithRedisCallback(key)
+        }
+    }
+
+    private fun incrementWithRedisCallback(key: String) {
+        val result = redisTemplate.execute(object : SessionCallback<List<Any>> {
+            override fun <K : Any, V : Any> execute(operations: RedisOperations<K, V>): List<Any> {
+                redisTemplate.watch(key)
+                val currentValue = redisTemplate.opsForValue().get(key) ?: 0
+                redisTemplate.multi()
+                return try {
+                    redisTemplate.opsForValue().set(key, currentValue + 1)
+                    redisTemplate.exec()
+                } catch (e: Exception) {
+                    log.error { "Error: $e" }
+                    redisTemplate.discard()
+                    throw e
+                } finally {
+                    redisTemplate.unwatch()
+                }
+            }
+        })
+
+        if (result.isEmpty()) {
+            log.error { "트랜잭션 실패: 다른 클라이언트에 의해 키가 변경되었습니다." }
+            throw RuntimeException("트랜잭션 실패: 다른 클라이언트에 의해 키가 변경되었습니다.")
+        }
+    }
+}

--- a/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationServiceTests.kt
+++ b/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationServiceTests.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.test.context.ActiveProfiles
 import java.util.concurrent.CompletableFuture
 
+@ActiveProfiles("test")
 @SpringBootTest
 class AtomicOperationServiceTests {
     @Autowired
@@ -27,7 +29,6 @@ class AtomicOperationServiceTests {
         }
 
         // when
-
         val futures = mutableListOf<CompletableFuture<Void>>()
         repeat(2) {
             val future = CompletableFuture.runAsync {

--- a/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationServiceTests.kt
+++ b/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationServiceTests.kt
@@ -31,9 +31,10 @@ class AtomicOperationServiceTests {
         // when
         val futures = mutableListOf<CompletableFuture<Void>>()
         repeat(2) {
-            val future = CompletableFuture.runAsync {
-                atomicOperationService.increment(key, true)
-            }
+            val future =
+                CompletableFuture.runAsync {
+                    atomicOperationService.increment(key, true)
+                }
 
             futures.add(future)
         }

--- a/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationServiceTests.kt
+++ b/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/AtomicOperationServiceTests.kt
@@ -1,0 +1,45 @@
+package kr.co.taek.dev.redis.example.concurrency.transaction
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.RedisTemplate
+import java.util.concurrent.CompletableFuture
+
+@SpringBootTest
+class AtomicOperationServiceTests {
+    @Autowired
+    private lateinit var atomicOperationService: AtomicOperationService
+
+    @Autowired
+    private lateinit var redisTemplate: RedisTemplate<String, Int>
+
+    @DisplayName("2개의 스레드가 동시에 Redis에 접근하여 값을 증가시키더라도 레디스 트랜잭션에 의해 값이 각각 1씩 증가한다.")
+    @Test
+    fun increment_with_redis_transaction() {
+        // given
+        val key = "test"
+
+        redisTemplate.opsForValue().get(key)?.let {
+            redisTemplate.delete(key)
+        }
+
+        // when
+
+        val futures = mutableListOf<CompletableFuture<Void>>()
+        repeat(2) {
+            val future = CompletableFuture.runAsync {
+                atomicOperationService.increment(key, true)
+            }
+
+            futures.add(future)
+        }
+
+        futures.forEach { it.join() }
+
+        // then
+        redisTemplate.opsForValue().get(key) shouldBe 2
+    }
+}

--- a/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/config/RedisTestConfig.kt
+++ b/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/config/RedisTestConfig.kt
@@ -14,21 +14,22 @@ import org.testcontainers.utility.DockerImageName
 @Profile("test")
 @Configuration
 class RedisTestConfig {
-   @Bean(initMethod = "start", destroyMethod = "stop")
-   fun redisContainer(): RedisContainer {
-       return RedisContainer(DockerImageName.parse("redis:latest"))
-   }
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    fun redisContainer(): RedisContainer {
+        return RedisContainer(DockerImageName.parse("redis:latest"))
+    }
 
-   @Bean
-   @DependsOn("redisContainer")
-   fun redissonClient(redisContainer: RedisContainer): RedissonClient {
-       val host = redisContainer.host
-       val port = redisContainer.firstMappedPort
-       val config = Config().apply {
-           this.useSingleServer().address = "redis://$host:$port"
-       }
-       return Redisson.create(config)
-   }
+    @Bean
+    @DependsOn("redisContainer")
+    fun redissonClient(redisContainer: RedisContainer): RedissonClient {
+        val host = redisContainer.host
+        val port = redisContainer.firstMappedPort
+        val config =
+            Config().apply {
+                this.useSingleServer().address = "redis://$host:$port"
+            }
+        return Redisson.create(config)
+    }
 
     @Bean
     @DependsOn("redisContainer")

--- a/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/config/RedisTestConfig.kt
+++ b/concurrency/src/test/kotlin/kr/co/taek/dev/redis/example/concurrency/transaction/config/RedisTestConfig.kt
@@ -1,0 +1,38 @@
+package kr.co.taek.dev.redis.example.concurrency.transaction.config
+
+import com.redis.testcontainers.RedisContainer
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
+import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.testcontainers.utility.DockerImageName
+
+@Profile("test")
+@Configuration
+class RedisTestConfig {
+   @Bean(initMethod = "start", destroyMethod = "stop")
+   fun redisContainer(): RedisContainer {
+       return RedisContainer(DockerImageName.parse("redis:latest"))
+   }
+
+   @Bean
+   @DependsOn("redisContainer")
+   fun redissonClient(redisContainer: RedisContainer): RedissonClient {
+       val host = redisContainer.host
+       val port = redisContainer.firstMappedPort
+       val config = Config().apply {
+           this.useSingleServer().address = "redis://$host:$port"
+       }
+       return Redisson.create(config)
+   }
+
+    @Bean
+    @DependsOn("redisContainer")
+    fun lettuceConnectionFactory(redisContainer: RedisContainer): LettuceConnectionFactory {
+        return LettuceConnectionFactory(redisContainer.host, redisContainer.firstMappedPort)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotest = "5.8.0"
 spring-boot = "3.2.1"
 spring-dependency-management = "1.1.4"
 spring-boot-tarter-redisson = "3.35.0"
+spring-boot-starter-data-redis = "3.3.3"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}
@@ -37,4 +38,5 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 
 # redisson
 spring-boot-starter-redisson = { module = "org.redisson:redisson-spring-boot-starter", version.ref = "spring-boot-tarter-redisson" }
+spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis", version.ref = "spring-boot-starter-data-redis" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ spring-boot = "3.2.1"
 spring-dependency-management = "1.1.4"
 spring-boot-tarter-redisson = "3.35.0"
 spring-boot-starter-data-redis = "3.3.3"
+testcontainers = "1.20.1"
+testcontainers-redis = "1.6.4"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}
@@ -28,6 +30,9 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 
+testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
+testcontainers-redis = { module = "com.redis.testcontainers:testcontainers-redis", version.ref = "testcontainers-redis" }
+
 # spring
 spring-context = { module = "org.springframework:spring-context" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
@@ -39,4 +44,3 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 # redisson
 spring-boot-starter-redisson = { module = "org.redisson:redisson-spring-boot-starter", version.ref = "spring-boot-tarter-redisson" }
 spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis", version.ref = "spring-boot-starter-data-redis" }
-


### PR DESCRIPTION
- spring-data-redis 를 사용하여 lettuce를 활용하여 작성.
- redisson-spring-boot-starter의 경우, watch 명령어 사용이 다른 커넥션에서 사용되는 이슈가 있음.
  - 이건 나중에 살펴보자.
- redisson transaction api는 다른 이슈에서 다뤄보기.